### PR TITLE
enabled compaction in couchdb default.ini

### DIFF
--- a/platform/packages/medic-core/settings/medic-core/couchdb/default.ini
+++ b/platform/packages/medic-core/settings/medic-core/couchdb/default.ini
@@ -348,5 +348,5 @@ min_file_size = 131072
 ;    Similar to the preceding example, but a database and its views can be
 ;    compacted in parallel.
 ;
-;_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "23:00"}, {to, "04:00"}]
+_default = [{db_fragmentation, "70%"}, {view_fragmentation, "60%"}, {from, "23:00"}, {to, "04:00"}]
 


### PR DESCRIPTION
Keeping this configuration in default.ini so that local.ini can override
if necessary.  It's also easy to push a new default.ini to all servers
without worrying about affecting too much since the local.ini is not
affected.